### PR TITLE
feat: Upgrade docker images to the latest stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![Build Status](https://travis-ci.org/krlv/service-skeleton.svg?branch=master)](https://travis-ci.org/krlv/service-skeleton)
 [![Coverage Status](https://coveralls.io/repos/github/krlv/service-skeleton/badge.svg?branch=master)](https://coveralls.io/github/krlv/service-skeleton?branch=master)
 
-This skeleton application is based on Slim Framework 3 Skeleton Application
+This skeleton application is based on Slim Framework 4 Skeleton Application

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:stable-alpine
+FROM nginx:1.18.0-alpine
 
 COPY www.conf /etc/nginx/conf.d/default.conf

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm-alpine
+FROM php:7.4-fpm-alpine
 
 RUN docker-php-source extract \
     && apk add --update --no-cache --virtual .build-deps $PHPIZE_DEPS \


### PR DESCRIPTION
Resolves #37

- php-fpm docker image upgraded to v7.4
- php-fpm Travis CI minimum version changed to v7.4
- nginx docker image upgraded to v1.18.0
